### PR TITLE
feat(deploy): add Vercel preview setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "vercel-build": "tsc -b && vite build && cp -r content dist/content",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "npm run vercel-build",
+  "outputDirectory": "dist",
+  "framework": "vite",
+  "git": {
+    "deploymentEnabled": {
+      "main": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `vercel.json` + `vercel-build` npm script so feature branches deploy to per-branch `*.vercel.app` preview URLs for stakeholder review without touching production.
- `git.deploymentEnabled.main: false` — Vercel does NOT deploy main; production stays on GitHub Pages (`t-club.ca`) as the single canonical source.
- `vercel-build` mirrors what `.github/workflows/deploy.yml` does (`tsc -b && vite build && cp -r content dist/content`).

## Why
We need a way to share draft month pages with stakeholders (Ksusha, Nana) for review **without publishing to t-club.ca first**. Vercel preview deployments per branch solve this. Google indexing isn't a concern: Vercel auto-applies `X-Robots-Tag: noindex` to all non-production deploys.

## After merge — one-time manual step
1. Connect repo at https://vercel.com/new (import `olegleyz/tclub`).
2. Settings → Deployment Protection → **disable** (otherwise reviewers without a Vercel account can't view preview URLs).
3. From now on: push a feature branch → Vercel automatically builds + comments preview URL on the PR.

## Test plan
- [ ] After merge: connect repo to Vercel; verify Vercel reads `vercel.json` (build command, framework, deploymentEnabled).
- [ ] Push the next feature branch (e.g. `may-2026`); confirm preview URL is generated and main does NOT deploy.
- [ ] Confirm `X-Robots-Tag: noindex` is present on the preview URL via `curl -I`.
- [ ] Confirm production at `t-club.ca` continues to deploy from GH Pages on merges to main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured the build and deployment pipeline to optimize the production release process and ensure consistency across deployment environments.
  * Updated static asset management to guarantee all application resources are properly included and bundled during the build phase for seamless production deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->