### PR TITLE
Redesign homepage as editorial art-journal issue

### DIFF
--- a/src/components/home/AboutSection.tsx
+++ b/src/components/home/AboutSection.tsx
@@ -11,20 +11,58 @@ export default function AboutSection({ config }: Props) {
   const { about } = config;
 
   return (
-    <section id="about" className="py-24 px-4">
-      <div className="max-w-2xl mx-auto text-center">
-        <span className="line-ornament mb-6" />
-        <h2 className="font-serif text-3xl md:text-4xl font-light text-text-hover mb-10 italic">
-          {t(ui.aboutClub)}
-        </h2>
-        <p className="font-serif text-xl md:text-2xl text-text-hover font-light leading-relaxed mb-6">
-          {t(about.mission)}
-        </p>
-        <p className="text-text mb-8 leading-loose text-[0.95rem]">{t(about.description)}</p>
-        <p className="text-accent text-sm tracking-[0.2em] uppercase mb-8">{t(about.tags)}</p>
-        <div className="border-t border-divider pt-6 max-w-xs mx-auto">
-          <p className="font-serif text-text italic text-lg mb-1">{t(about.atmosphere)}</p>
-          <p className="text-text text-sm">{t(about.audience)}</p>
+    <section id="about" className="relative py-28 md:py-36 px-6 md:px-10">
+      <div className="max-w-[1400px] mx-auto">
+        <div className="rule-strip mb-16">
+          <span className="rule-label text-clay">§ 01</span>
+          <span className="rule-line" />
+          <span className="rule-label">{t(ui.aboutClub)}</span>
+          <span className="rule-line" />
+        </div>
+
+        <div className="grid lg:grid-cols-12 gap-x-10 gap-y-14">
+          {/* Side metadata */}
+          <aside className="lg:col-span-3">
+            <div className="lg:sticky lg:top-32 space-y-7">
+              <div>
+                <p className="mono-cap-sm text-clay mb-2">— I —</p>
+                <p
+                  className="font-serif italic text-ink leading-snug text-lg"
+                  style={{ fontVariationSettings: "'opsz' 18, 'SOFT' 60" }}
+                >
+                  {t(about.atmosphere)}
+                </p>
+              </div>
+              <div>
+                <p className="mono-cap-sm text-clay mb-2">— II —</p>
+                <p className="text-ink-soft text-sm leading-relaxed">
+                  {t(about.audience)}
+                </p>
+              </div>
+              <div className="pt-5 border-t border-ink/10">
+                <p className="mono-cap-sm">{t(about.tags)}</p>
+              </div>
+            </div>
+          </aside>
+
+          {/* Main column — pull quote + body */}
+          <div className="lg:col-span-9 lg:pl-10 lg:border-l lg:border-ink/10">
+            <p
+              className="display-italic mb-12"
+              style={{
+                fontSize: 'clamp(2rem, 4.5vw, 4rem)',
+                fontVariationSettings: "'opsz' 96, 'SOFT' 60, 'WONK' 1",
+              }}
+            >
+              <span aria-hidden className="text-clay/70 mr-2" style={{ fontStyle: 'normal' }}>“</span>
+              {t(about.mission)}
+              <span aria-hidden className="text-clay/70 ml-1" style={{ fontStyle: 'normal' }}>”</span>
+            </p>
+
+            <p className="max-w-2xl text-ink leading-[1.8] text-[1.02rem]">
+              {t(about.description)}
+            </p>
+          </div>
         </div>
       </div>
     </section>

--- a/src/components/home/ContactSection.tsx
+++ b/src/components/home/ContactSection.tsx
@@ -1,44 +1,83 @@
 import { useLang } from '../../hooks/useLang';
 import { ui } from '../../lib/ui-strings';
+import { useSiteConfig } from '../../hooks/useContent';
 
 export default function ContactSection() {
   const { t } = useLang();
+  const config = useSiteConfig();
 
   return (
-    <section className="py-24 px-4">
-      <div className="max-w-sm mx-auto">
-        <div className="text-center mb-10">
-          <span className="line-ornament mb-6" />
-          <h2 className="font-serif text-3xl md:text-4xl font-light text-text-hover italic">
-            {t(ui.contactUs)}
-          </h2>
+    <section className="relative py-28 md:py-36 px-6 md:px-10">
+      <div className="max-w-[1400px] mx-auto">
+        <div className="rule-strip mb-16">
+          <span className="rule-label text-clay">§ 08</span>
+          <span className="rule-line" />
+          <span className="rule-label">{t(ui.contactUs)}</span>
+          <span className="rule-line" />
         </div>
-        <form
-          action="https://formspree.io/f/PLACEHOLDER"
-          method="POST"
-          className="space-y-5"
-        >
-          <input
-            type="text"
-            name="name"
-            placeholder={t(ui.yourName)}
-            required
-            className="w-full px-4 py-3 bg-transparent border-b border-divider text-text-hover placeholder:text-text/40 focus:outline-none focus:border-accent transition-colors"
-          />
-          <textarea
-            name="message"
-            placeholder={t(ui.message)}
-            rows={4}
-            required
-            className="w-full px-4 py-3 bg-transparent border-b border-divider text-text-hover placeholder:text-text/40 focus:outline-none focus:border-accent transition-colors resize-none"
-          />
-          <button
-            type="submit"
-            className="w-full px-8 py-3 border border-accent/40 text-accent hover:bg-accent hover:text-white transition-all duration-300 text-sm tracking-[0.15em] uppercase cursor-pointer"
+
+        <div className="grid lg:grid-cols-12 gap-x-12 gap-y-12">
+          <div className="lg:col-span-5">
+            <h2
+              className="display-italic mb-6"
+              style={{
+                fontSize: 'clamp(2.4rem, 5.5vw, 5rem)',
+                fontVariationSettings: "'opsz' 144, 'SOFT' 80, 'WONK' 1",
+              }}
+            >
+              {t(ui.contactUs)}
+            </h2>
+            <div className="mt-6 h-px w-24 bg-clay/60" />
+          </div>
+
+          <form
+            action="https://formspree.io/f/PLACEHOLDER"
+            method="POST"
+            className="lg:col-span-7 space-y-9"
           >
-            {t(ui.send)}
-          </button>
-        </form>
+            <label className="block">
+              <span className="mono-cap-sm text-clay">— I — {t(ui.yourName)}</span>
+              <input
+                type="text"
+                name="name"
+                placeholder=""
+                required
+                className="mt-3 w-full bg-transparent border-0 border-b border-ink/30 px-0 py-3 text-ink text-lg font-serif italic focus:outline-none focus:border-clay transition-colors"
+                style={{ fontVariationSettings: "'opsz' 24, 'SOFT' 50" }}
+              />
+            </label>
+
+            <label className="block">
+              <span className="mono-cap-sm text-clay">— II — {t(ui.message)}</span>
+              <textarea
+                name="message"
+                placeholder=""
+                rows={4}
+                required
+                className="mt-3 w-full bg-transparent border-0 border-b border-ink/30 px-0 py-3 text-ink text-lg font-serif italic focus:outline-none focus:border-clay transition-colors resize-none"
+                style={{ fontVariationSettings: "'opsz' 24, 'SOFT' 50" }}
+              />
+            </label>
+
+            <button
+              type="submit"
+              className="group inline-flex items-center gap-4 bg-ink text-paper px-8 py-4 hover:bg-clay transition-colors duration-400 cursor-pointer"
+            >
+              <span className="mono-cap-sm">{t(ui.send)}</span>
+              <span className="w-8 h-px bg-paper transition-all duration-400 group-hover:w-14" />
+              <span aria-hidden>→</span>
+            </button>
+          </form>
+        </div>
+
+        {/* Footer rule strip */}
+        <div className="rule-strip mt-28">
+          <span className="rule-label">— {config ? t(config.about.title) : ''} —</span>
+          <span className="rule-line" />
+          <span className="rule-label">{t(ui.volume)} · {t(ui.issueLabel)} 05 / 26</span>
+          <span className="rule-line" />
+          <span className="rule-label text-clay">{t(ui.inSession)}</span>
+        </div>
       </div>
     </section>
   );

--- a/src/components/home/GuestSection.tsx
+++ b/src/components/home/GuestSection.tsx
@@ -14,23 +14,49 @@ export default function GuestSection({ month }: Props) {
   const guests = month.guests;
 
   if (!guests || guests.length === 0) return null;
-
   const single = guests.length === 1;
 
   return (
-    <section className="py-24 px-4 relative overflow-hidden">
-      <div className="absolute inset-0 bg-gradient-to-br from-bg-warm to-bg opacity-80" />
-      <div className="max-w-3xl mx-auto text-center relative">
-        <span className="line-ornament mb-6" />
-        <h2 className="font-serif text-3xl md:text-4xl font-light text-text-hover mb-14 italic">
+    <section className="relative py-28 md:py-36 px-6 md:px-10 overflow-hidden">
+      {/* Soft moss wash to accent the body theme */}
+      <div
+        aria-hidden
+        className="absolute inset-0 pointer-events-none"
+        style={{
+          background:
+            'radial-gradient(ellipse 60% 80% at 90% 50%, rgba(177,75,42,0.05) 0%, transparent 60%), radial-gradient(ellipse 70% 90% at 5% 30%, rgba(90,103,69,0.06) 0%, transparent 65%)',
+        }}
+      />
+
+      <div className="relative max-w-[1400px] mx-auto">
+        <div className="rule-strip mb-16">
+          <span className="rule-label text-clay">§ 05</span>
+          <span className="rule-line" />
+          <span className="rule-label">
+            {single ? t(ui.guestOfMonth) : t(ui.guestsOfMonth)}
+          </span>
+          <span className="rule-line" />
+          <span className="rule-label hidden md:inline">
+            {guests.length.toString().padStart(2, '0')} · {t(ui.portrait)}
+          </span>
+        </div>
+
+        <h2
+          className="display-italic mb-20 max-w-4xl"
+          style={{
+            fontSize: 'clamp(2.5rem, 7vw, 6.5rem)',
+            fontVariationSettings: "'opsz' 144, 'SOFT' 80, 'WONK' 1",
+          }}
+        >
           {single ? t(ui.guestOfMonth) : t(ui.guestsOfMonth)}
         </h2>
+
         {single ? (
           <SingleGuest guest={guests[0]} t={t} />
         ) : (
-          <div className="grid sm:grid-cols-2 gap-12">
+          <div className="space-y-24 md:space-y-32">
             {guests.map((g, i) => (
-              <MultiGuest key={i} guest={g} t={t} />
+              <GuestRow key={i} guest={g} index={i} total={guests.length} t={t} />
             ))}
           </div>
         )}
@@ -41,38 +67,141 @@ export default function GuestSection({ month }: Props) {
 
 function SingleGuest({ guest, t }: { guest: Guest; t: T }) {
   return (
-    <>
-      <div className="w-44 h-44 rounded-full overflow-hidden mx-auto mb-8 ring-1 ring-accent/20 ring-offset-4 ring-offset-bg-warm">
-        <img
-          src={assetUrl(guest.image)}
-          alt={t(guest.name)}
-          loading="lazy"
-          decoding="async"
-          className="w-full h-full object-cover object-top"
-        />
+    <div className="grid md:grid-cols-12 gap-x-10 gap-y-10 items-center">
+      <figure className="md:col-span-5 relative">
+        <div className="paper-frame" style={{ transform: 'rotate(-1.4deg)' }}>
+          <div className="aspect-[4/5] overflow-hidden">
+            <img
+              src={assetUrl(guest.image)}
+              alt={t(guest.name)}
+              loading="lazy"
+              decoding="async"
+              className="w-full h-full object-cover object-top"
+              style={{ filter: 'sepia(0.1) saturate(0.96)' }}
+            />
+          </div>
+          <span className="tape" style={{ top: '-8px', left: '40px', transform: 'rotate(-5deg)' }} />
+        </div>
+        <figcaption className="mt-4 mono-cap-sm text-ink-soft">
+          <span className="text-clay">Fig. 01</span> — Guest portrait
+        </figcaption>
+      </figure>
+      <div className="md:col-span-7 md:pl-8">
+        <h3
+          className="font-serif italic text-ink mb-3 leading-[0.95]"
+          style={{
+            fontSize: 'clamp(2.5rem, 5vw, 4.5rem)',
+            fontVariationSettings: "'opsz' 96, 'SOFT' 70, 'WONK' 1",
+          }}
+        >
+          {t(guest.name)}
+        </h3>
+        <p className="mono-cap-sm text-clay mb-6">{t(guest.role)}</p>
+        {guest.bio && (
+          <p
+            className="font-serif text-lg md:text-xl text-ink-soft leading-[1.65] max-w-2xl"
+            style={{ fontVariationSettings: "'opsz' 18, 'SOFT' 30" }}
+          >
+            {t(guest.bio)}
+          </p>
+        )}
       </div>
-      <h3 className="font-serif text-text-hover text-2xl mb-1 italic">{t(guest.name)}</h3>
-      <p className="text-accent text-sm tracking-wide mb-5">{t(guest.role)}</p>
-      {guest.bio && <p className="text-text leading-relaxed max-w-md mx-auto">{t(guest.bio)}</p>}
-    </>
+    </div>
   );
 }
 
-function MultiGuest({ guest, t }: { guest: Guest; t: T }) {
-  return (
-    <div className="flex flex-col items-center">
-      <div className="w-36 h-36 rounded-full overflow-hidden mb-6 ring-1 ring-accent/20 ring-offset-4 ring-offset-bg-warm">
-        <img
-          src={assetUrl(guest.image)}
-          alt={t(guest.name)}
-          loading="lazy"
-          decoding="async"
-          className="w-full h-full object-cover object-top"
+function GuestRow({
+  guest,
+  index,
+  total,
+  t,
+}: {
+  guest: Guest;
+  index: number;
+  total: number;
+  t: T;
+}) {
+  const layouts = [
+    { imgSide: 'left' as const, imgSpan: 'md:col-span-5', txtSpan: 'md:col-span-6 md:col-start-7', rotate: -1.6, aspect: '4/5', tape: { top: '-8px', left: '32px', rotate: '-4deg' } },
+    { imgSide: 'right' as const, imgSpan: 'md:col-span-4 md:col-start-8', txtSpan: 'md:col-span-6 md:col-start-1 md:mt-12', rotate: 1.2, aspect: '3/4', tape: { top: '-8px', right: '28px', rotate: '4deg' } },
+    { imgSide: 'left' as const, imgSpan: 'md:col-span-4 md:col-start-2', txtSpan: 'md:col-span-5 md:col-start-7 md:mt-20', rotate: -0.8, aspect: '4/5', tape: { top: '-8px', right: '40px', rotate: '-3deg' } },
+    { imgSide: 'right' as const, imgSpan: 'md:col-span-5 md:col-start-7', txtSpan: 'md:col-span-5 md:col-start-1', rotate: 1.4, aspect: '3/4', tape: { top: '-8px', left: '36px', rotate: '5deg' } },
+    { imgSide: 'left' as const, imgSpan: 'md:col-span-6', txtSpan: 'md:col-span-5 md:col-start-8 md:mt-16', rotate: -1.1, aspect: '4/5', tape: { top: '-8px', left: '50px', rotate: '-2deg' } },
+  ];
+  const layout = layouts[index % layouts.length];
+  const fig = String(index + 2).padStart(2, '0'); // start at 02, hero photo was Fig. 01
+
+  const imageBlock = (
+    <figure className={`relative ${layout.imgSpan}`}>
+      <div className="paper-frame" style={{ transform: `rotate(${layout.rotate}deg)` }}>
+        <div className="overflow-hidden" style={{ aspectRatio: layout.aspect }}>
+          <img
+            src={assetUrl(guest.image)}
+            alt={t(guest.name)}
+            loading="lazy"
+            decoding="async"
+            className="w-full h-full object-cover object-top transition-transform duration-700 ease-out hover:scale-[1.03]"
+            style={{ filter: 'sepia(0.1) saturate(0.95)' }}
+          />
+        </div>
+        <span
+          className="tape"
+          style={{
+            top: layout.tape.top,
+            left: (layout.tape as { left?: string }).left,
+            right: (layout.tape as { right?: string }).right,
+            transform: `rotate(${layout.tape.rotate})`,
+          }}
         />
       </div>
-      <h3 className="font-serif text-text-hover text-xl mb-1 italic">{t(guest.name)}</h3>
-      <p className="text-accent text-sm tracking-wide mb-4">{t(guest.role)}</p>
-      {guest.bio && <p className="text-text leading-relaxed text-[0.95rem]">{t(guest.bio)}</p>}
+      <figcaption className="mt-3 flex items-center gap-3 mono-cap-sm text-ink-soft">
+        <span className="text-clay">Fig. {fig}</span>
+        <span className="h-px w-10 bg-ink/20" />
+        <span className="opacity-70">— {String(index + 1)} / {total} —</span>
+      </figcaption>
+    </figure>
+  );
+
+  const textBlock = (
+    <div className={layout.txtSpan}>
+      <div className="flex items-baseline gap-3 mb-4">
+        <span className="mono-cap-sm text-clay">No. {String(index + 1).padStart(2, '0')}</span>
+        <span className="h-px flex-1 max-w-[80px] bg-ink/15" />
+      </div>
+      <h3
+        className="font-serif italic text-ink mb-3 leading-[0.95]"
+        style={{
+          fontSize: 'clamp(2rem, 4vw, 3.5rem)',
+          fontVariationSettings: "'opsz' 72, 'SOFT' 70, 'WONK' 1",
+        }}
+      >
+        {t(guest.name)}
+      </h3>
+      <p className="mono-cap-sm text-clay mb-5">{t(guest.role)}</p>
+      {guest.bio && (
+        <p
+          className="font-serif text-base md:text-lg text-ink-soft leading-[1.7] max-w-[42ch]"
+          style={{ fontVariationSettings: "'opsz' 18, 'SOFT' 30" }}
+        >
+          {t(guest.bio)}
+        </p>
+      )}
     </div>
+  );
+
+  return (
+    <article className="grid md:grid-cols-12 gap-x-10 gap-y-10 items-start">
+      {layout.imgSide === 'left' ? (
+        <>
+          {imageBlock}
+          {textBlock}
+        </>
+      ) : (
+        <>
+          {textBlock}
+          {imageBlock}
+        </>
+      )}
+    </article>
   );
 }

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -10,42 +10,173 @@ interface Props {
 
 export default function HeroSection({ config, month }: Props) {
   const { t } = useLang();
-
   const monthLabel = monthNames[String(month.month)];
+  const themeTitle = t(month.theme.title);
+
+  // Split the theme title onto two cascading lines (e.g. "Моё" / "Тело", "My" / "Body")
+  const parts = themeTitle.trim().split(/\s+/);
+  const lineA = parts.slice(0, Math.max(1, Math.ceil(parts.length / 2))).join(' ');
+  const lineB = parts.slice(Math.max(1, Math.ceil(parts.length / 2))).join(' ');
 
   return (
     <section
-      className="relative min-h-screen flex items-center justify-center text-center px-4"
-      style={{
-        backgroundImage: `url(${import.meta.env.BASE_URL}images/backgrounds/hero-bg.jpg)`,
-        backgroundSize: 'cover',
-        backgroundPosition: 'center',
-      }}
+      className="relative pt-32 md:pt-36 pb-20 md:pb-28 px-6 md:px-10 overflow-hidden"
+      aria-label="Hero"
     >
-      <div className="absolute inset-0 bg-gradient-to-b from-[#F5EFE3]/60 via-[#F5EFE3]/30 to-[#F5EFE3]/80" />
-      <div className="relative z-10 max-w-2xl">
-        <div className="animate-fade-up" style={{ animationDelay: '0.1s' }}>
-          <span className="line-ornament mb-6" />
+      {/* Faint photographic atmosphere — kept as soft wash, not full-bleed */}
+      <div
+        aria-hidden
+        className="absolute right-0 top-0 w-[55%] h-[60%] opacity-20 pointer-events-none"
+        style={{
+          backgroundImage: `url(${import.meta.env.BASE_URL}images/backgrounds/hero-bg.jpg)`,
+          backgroundSize: 'cover',
+          backgroundPosition: 'center',
+          maskImage: 'radial-gradient(ellipse at 70% 30%, rgba(0,0,0,0.8), transparent 70%)',
+          WebkitMaskImage: 'radial-gradient(ellipse at 70% 30%, rgba(0,0,0,0.8), transparent 70%)',
+        }}
+      />
+
+      <div className="relative max-w-[1400px] mx-auto">
+        {/* Mast rule */}
+        <div className="rule-strip mb-14 md:mb-20 animate-fade-in" style={{ animationDelay: '0.05s' }}>
+          <span className="rule-label">— {t(config.about.title)} —</span>
+          <span className="rule-line" />
+          <span className="rule-label hidden sm:inline">{t(ui.volume)} · {t(ui.issueLabel)} 05 / 26</span>
+          <span className="rule-line hidden sm:block" />
+          <span className="rule-label text-clay">{t(ui.inSession)}</span>
         </div>
-        <h1
-          className="font-serif text-[2.5rem] md:text-7xl font-light text-text-hover mb-5 tracking-tight italic animate-fade-up"
-          style={{ animationDelay: '0.2s' }}
-        >
-          {t(config.about.title)}
-        </h1>
-        <p
-          className="text-base md:text-lg text-text mb-10 tracking-wide animate-fade-up"
-          style={{ animationDelay: '0.4s' }}
-        >
-          {monthLabel ? t(monthLabel) : ''} · {t(month.theme.title)}
-        </p>
-        <button
-          onClick={() => document.getElementById('about')?.scrollIntoView({ behavior: 'smooth' })}
-          className="animate-fade-up inline-block px-8 py-3 border border-accent/40 text-accent rounded-none hover:bg-accent hover:text-white transition-all duration-300 text-sm tracking-[0.15em] uppercase font-sans cursor-pointer"
-          style={{ animationDelay: '0.6s' }}
-        >
-          {t(ui.learnMore)}
-        </button>
+
+        <div className="grid lg:grid-cols-12 gap-x-10 gap-y-12 items-start">
+          {/* LEFT — display title column */}
+          <div className="lg:col-span-8 relative">
+            {/* Kicker */}
+            <div className="flex items-baseline gap-4 mb-5 animate-fade-up" style={{ animationDelay: '0.15s' }}>
+              <span className="mono-cap text-clay">{t(ui.monthTheme)}</span>
+              <span className="h-px w-12 bg-clay/40" />
+              <span className="mono-cap text-ink-soft">
+                {monthLabel ? t(monthLabel) : ''} · {month.year}
+              </span>
+            </div>
+
+            {/* Cascading italic display — the theme as cover */}
+            <h1
+              className="relative leading-[0.86] tracking-tight"
+              style={{ fontFamily: 'var(--font-serif)' }}
+            >
+              <span
+                className="block animate-fade-up font-light italic"
+                style={{
+                  fontSize: 'clamp(3.5rem, 13vw, 11rem)',
+                  fontVariationSettings: "'opsz' 144, 'SOFT' 80, 'WONK' 1",
+                  color: 'var(--color-ink)',
+                  letterSpacing: '-0.03em',
+                  animationDelay: '0.25s',
+                }}
+              >
+                {lineA}
+              </span>
+              {lineB && (
+                <span
+                  className="block animate-fade-up pl-[12%] md:pl-[22%]"
+                  style={{
+                    fontSize: 'clamp(3.5rem, 13vw, 11rem)',
+                    fontVariationSettings: "'opsz' 144, 'SOFT' 30, 'WONK' 0",
+                    color: 'var(--color-clay)',
+                    letterSpacing: '-0.03em',
+                    fontWeight: 350,
+                    fontStyle: 'normal',
+                    animationDelay: '0.45s',
+                    marginTop: '-0.05em',
+                  }}
+                >
+                  {lineB}
+                  <span
+                    aria-hidden
+                    className="inline-block ml-3 align-baseline text-clay/70"
+                    style={{ fontSize: '0.18em' }}
+                  >
+                    ✦
+                  </span>
+                </span>
+              )}
+            </h1>
+
+            {/* Theme description */}
+            <p
+              className="mt-10 md:mt-12 max-w-xl text-lg md:text-xl text-ink leading-[1.55] font-serif animate-fade-up"
+              style={{
+                fontVariationSettings: "'opsz' 16, 'SOFT' 30",
+                animationDelay: '0.65s',
+              }}
+            >
+              {t(month.theme.description)}
+            </p>
+
+            {/* CTA row */}
+            <div
+              className="mt-10 flex flex-wrap items-center gap-5 animate-fade-up"
+              style={{ animationDelay: '0.8s' }}
+            >
+              <button
+                onClick={() => document.getElementById('about')?.scrollIntoView({ behavior: 'smooth' })}
+                className="group inline-flex items-center gap-3 bg-ink text-paper px-7 py-3.5 hover:bg-clay transition-colors duration-400 cursor-pointer"
+              >
+                <span className="mono-cap-sm">{t(ui.learnMore)}</span>
+                <span className="w-6 h-px bg-paper transition-all duration-400 group-hover:w-10" />
+              </button>
+              <a
+                href="#pricing"
+                onClick={(e) => {
+                  e.preventDefault();
+                  document.getElementById('pricing')?.scrollIntoView({ behavior: 'smooth' });
+                }}
+                className="mono-cap-sm text-ink hover:text-clay transition-colors ed-link no-underline"
+              >
+                {t(ui.subscribe)} →
+              </a>
+            </div>
+          </div>
+
+          {/* RIGHT — paper-frame portrait + editorial note */}
+          <aside className="lg:col-span-4 lg:pt-16 animate-fade-up" style={{ animationDelay: '0.55s' }}>
+            <figure className="relative">
+              <div
+                className="paper-frame"
+                style={{ transform: 'rotate(-1.2deg)' }}
+              >
+                <div className="aspect-[3/4] overflow-hidden">
+                  <img
+                    src={`${import.meta.env.BASE_URL}images/backgrounds/hero-bg.jpg`}
+                    alt=""
+                    className="w-full h-full object-cover"
+                    style={{ filter: 'sepia(0.18) contrast(1.02) saturate(0.92)' }}
+                  />
+                </div>
+                <span className="tape" style={{ top: '-8px', left: '24px', transform: 'rotate(-4deg)' }} />
+                <span className="tape" style={{ top: '-8px', right: '24px', transform: 'rotate(3deg)' }} />
+              </div>
+              <figcaption className="mt-4 flex items-start gap-3 mono-cap-sm text-ink-soft">
+                <span className="text-clay">Fig. 01</span>
+                <span className="opacity-70">— {t(ui.cover)} · {monthLabel ? t(monthLabel) : ''} {month.year}</span>
+              </figcaption>
+            </figure>
+
+            <div className="mt-9 pl-4 border-l border-ink/15">
+              <p className="mono-cap-sm text-clay mb-3">{t(ui.editorsNote)}</p>
+              <p className="font-serif text-base text-ink-soft leading-relaxed italic"
+                 style={{ fontVariationSettings: "'opsz' 14, 'SOFT' 50" }}>
+                {t(month.closingMessage)}
+              </p>
+            </div>
+          </aside>
+        </div>
+
+        {/* Scroll cue */}
+        <div className="mt-20 md:mt-28 flex items-center gap-3 mono-cap-sm text-ink-soft/80 animate-fade-in" style={{ animationDelay: '1.05s' }}>
+          <span>{t(ui.beginReading)}</span>
+          <span className="h-px w-16 bg-ink-soft/40" />
+          <span aria-hidden>↓</span>
+        </div>
       </div>
     </section>
   );

--- a/src/components/home/MonthScheduleSection.tsx
+++ b/src/components/home/MonthScheduleSection.tsx
@@ -12,22 +12,60 @@ export default function MonthScheduleSection({ month }: Props) {
   if (!month.schedule || month.schedule.length === 0) return null;
 
   return (
-    <section className="py-24 px-4">
-      <div className="max-w-2xl mx-auto">
-        <div className="text-center mb-12">
-          <span className="line-ornament mb-6" />
-          <h2 className="font-serif text-3xl md:text-4xl font-light text-text-hover italic">
-            {t(ui.monthSchedule)}
-          </h2>
+    <section className="relative py-28 md:py-36 px-6 md:px-10">
+      <div className="max-w-[1400px] mx-auto">
+        <div className="rule-strip mb-16">
+          <span className="rule-label text-clay">§ 03</span>
+          <span className="rule-line" />
+          <span className="rule-label">{t(ui.monthSchedule)}</span>
+          <span className="rule-line" />
         </div>
-        <ul className="space-y-4 text-left">
-          {month.schedule.map((item, i) => (
-            <li key={i} className="flex items-start gap-3 text-text leading-relaxed">
-              <span className="text-gold mt-1.5 text-sm" aria-hidden="true">&#10003;</span>
-              <span>{t(item)}</span>
-            </li>
-          ))}
-        </ul>
+
+        <div className="grid lg:grid-cols-12 gap-x-10 gap-y-12">
+          <div className="lg:col-span-4">
+            <h2
+              className="display-italic mb-6"
+              style={{
+                fontSize: 'clamp(2.2rem, 4.5vw, 4rem)',
+                fontVariationSettings: "'opsz' 144, 'SOFT' 70, 'WONK' 1",
+              }}
+            >
+              {t(ui.monthSchedule)}
+            </h2>
+            <p className="mono-cap-sm text-ink-soft">
+              {String(month.month).padStart(2, '0')} · {month.year}
+            </p>
+            <div className="mt-6 h-px w-20 bg-clay/50" />
+          </div>
+
+          <ul className="lg:col-span-8 divide-y divide-ink/15">
+            {month.schedule.map((item, i) => (
+              <li
+                key={i}
+                className="grid grid-cols-[auto_1fr_auto] items-baseline gap-5 py-5 group"
+              >
+                <span
+                  className="font-mono text-xs text-clay tabular-nums"
+                  style={{ letterSpacing: '0.05em' }}
+                >
+                  {String(i + 1).padStart(2, '0')}
+                </span>
+                <span
+                  className="font-serif text-lg md:text-xl text-ink leading-snug"
+                  style={{ fontVariationSettings: "'opsz' 24, 'SOFT' 40, 'WONK' 0" }}
+                >
+                  {t(item)}
+                </span>
+                <span
+                  aria-hidden
+                  className="text-clay/60 transition-transform duration-400 group-hover:translate-x-1"
+                >
+                  ↗
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
       </div>
     </section>
   );

--- a/src/components/home/MonthStructure.tsx
+++ b/src/components/home/MonthStructure.tsx
@@ -8,44 +8,85 @@ interface Props {
 
 export default function MonthStructure({ month }: Props) {
   const { t } = useLang();
+  const themeTitle = t(month.theme.title);
 
   return (
-    <section className="py-24 px-4 relative overflow-hidden">
-      <div className="absolute inset-0 bg-gradient-to-br from-bg-warm to-bg opacity-80" />
-      <div className="max-w-2xl mx-auto relative">
-        <div className="text-center mb-14">
-          <span className="line-ornament mb-6" />
-          <h2 className="font-serif text-3xl md:text-4xl font-light text-text-hover italic">
-            {t(ui.monthStructure)}
-          </h2>
-        </div>
-        <div className="space-y-10">
-          {/* Theme intro */}
-          <div className="flex gap-5">
-            <div className="flex-shrink-0 w-9 h-9 rounded-full border border-accent/40 flex items-center justify-center text-accent text-sm font-serif">
-              1
-            </div>
-            <div>
-              <h3 className="font-serif text-text-hover text-lg mb-2 italic">
-                {t(ui.monthTheme)}: {t(month.theme.title)}
-              </h3>
-              <p className="text-text leading-relaxed text-[0.95rem]">{t(month.theme.description)}</p>
-            </div>
-          </div>
+    <section className="relative py-28 md:py-36 px-6 md:px-10 overflow-hidden">
+      <div
+        aria-hidden
+        className="absolute inset-0 pointer-events-none"
+        style={{
+          background:
+            'linear-gradient(180deg, transparent 0%, rgba(90,103,69,0.04) 30%, rgba(90,103,69,0.07) 70%, transparent 100%)',
+        }}
+      />
 
-          {/* Sections */}
-          {month.sections.map((section, i) => (
-            <div key={i} className="flex gap-5">
-              <div className="flex-shrink-0 w-9 h-9 rounded-full border border-accent/40 flex items-center justify-center text-accent text-sm font-serif">
-                {i + 2}
-              </div>
-              <div>
-                <h3 className="font-serif text-text-hover text-lg mb-2 italic">{t(section.title)}</h3>
-                <p className="text-text leading-relaxed text-[0.95rem]">{t(section.description)}</p>
-              </div>
-            </div>
-          ))}
+      <div className="relative max-w-[1400px] mx-auto">
+        <div className="rule-strip mb-16">
+          <span className="rule-label text-clay">§ 02</span>
+          <span className="rule-line" />
+          <span className="rule-label">{t(ui.monthStructure)}</span>
+          <span className="rule-line" />
+          <span className="rule-label hidden md:inline">{themeTitle}</span>
         </div>
+
+        {/* Massive theme title */}
+        <div className="mb-20 md:mb-24 grid lg:grid-cols-12 gap-x-10 gap-y-8 items-end">
+          <div className="lg:col-span-7">
+            <p className="mono-cap-sm text-ink-soft mb-4">{t(ui.monthTheme)}</p>
+            <h2
+              className="display-italic"
+              style={{
+                fontSize: 'clamp(3rem, 9vw, 8rem)',
+                fontVariationSettings: "'opsz' 144, 'SOFT' 70, 'WONK' 1",
+              }}
+            >
+              {themeTitle}
+            </h2>
+          </div>
+          <div className="lg:col-span-5 lg:pl-12 lg:border-l lg:border-ink/15">
+            <p
+              className="font-serif text-lg md:text-xl text-ink leading-[1.55]"
+              style={{ fontVariationSettings: "'opsz' 18, 'SOFT' 40" }}
+            >
+              {t(month.theme.description)}
+            </p>
+          </div>
+        </div>
+
+        {/* Sections as numbered editorial entries */}
+        <ol className="grid md:grid-cols-3 gap-x-10 gap-y-14">
+          {month.sections.map((section, i) => (
+            <li key={i} className="group relative">
+              <div className="flex items-start justify-between mb-6">
+                <span
+                  className="font-serif text-clay leading-none"
+                  style={{
+                    fontSize: 'clamp(3rem, 5vw, 4.5rem)',
+                    fontVariationSettings: "'opsz' 144, 'SOFT' 0, 'WONK' 0",
+                    fontWeight: 300,
+                  }}
+                >
+                  {String(i + 1).padStart(2, '0')}
+                </span>
+                <span className="mono-cap-sm text-ink-soft mt-3">
+                  — {String(i + 1).padStart(2, '0')} / {String(month.sections.length).padStart(2, '0')}
+                </span>
+              </div>
+              <div className="h-px bg-ink/20 mb-6 origin-left animate-line-grow"
+                   style={{ animationDelay: `${0.1 + i * 0.1}s` }} />
+              <h3
+                className="font-serif text-2xl md:text-3xl text-ink mb-4 leading-tight italic"
+                style={{ fontVariationSettings: "'opsz' 36, 'SOFT' 50, 'WONK' 1" }}
+              >
+                {t(section.title)}
+              </h3>
+              <p className="text-ink-soft leading-relaxed text-[0.98rem]">
+                {t(section.description)}
+              </p>
+            </li>
+          ))}
+        </ol>
       </div>
     </section>
   );

--- a/src/components/home/OfferingsSection.tsx
+++ b/src/components/home/OfferingsSection.tsx
@@ -10,23 +10,61 @@ export default function OfferingsSection({ config }: Props) {
   const { t } = useLang();
 
   return (
-    <section className="py-24 px-4">
-      <div className="max-w-3xl mx-auto">
-        <div className="text-center mb-14">
-          <span className="line-ornament mb-6" />
-          <h2 className="font-serif text-3xl md:text-4xl font-light text-text-hover italic">
+    <section className="relative py-28 md:py-36 px-6 md:px-10">
+      <div className="max-w-[1400px] mx-auto">
+        <div className="rule-strip mb-16">
+          <span className="rule-label text-clay">§ 06</span>
+          <span className="rule-line" />
+          <span className="rule-label">{t(ui.whatsInside)}</span>
+          <span className="rule-line" />
+        </div>
+
+        <div className="grid md:grid-cols-12 gap-x-10 gap-y-10 mb-16 items-end">
+          <h2
+            className="md:col-span-8 display-italic"
+            style={{
+              fontSize: 'clamp(2.2rem, 5vw, 4.5rem)',
+              fontVariationSettings: "'opsz' 144, 'SOFT' 70, 'WONK' 1",
+            }}
+          >
             {t(ui.whatsInside)}
           </h2>
+          <div className="md:col-span-4 mono-cap-sm text-ink-soft md:text-right">
+            {config.offerings.length.toString().padStart(2, '0')} — {t(ui.monthTheme)}
+          </div>
         </div>
-        <div className="grid md:grid-cols-3 gap-8">
+
+        <div className="grid md:grid-cols-3 gap-6 md:gap-px md:bg-ink/10 md:border md:border-ink/10">
           {config.offerings.map((offering, i) => (
-            <div
+            <article
               key={i}
-              className="text-center p-8 border border-divider hover:border-accent/30 transition-colors duration-300"
+              className="editorial-card relative bg-paper p-8 md:p-10 hover:bg-paper-deep transition-colors duration-500"
             >
-              <h3 className="font-serif text-text-hover text-lg mb-3 italic">{t(offering.title)}</h3>
-              <p className="text-text text-sm leading-relaxed">{t(offering.description)}</p>
-            </div>
+              <div className="flex items-start justify-between mb-10">
+                <span
+                  className="font-serif text-clay leading-none"
+                  style={{
+                    fontSize: 'clamp(4rem, 7vw, 6rem)',
+                    fontVariationSettings: "'opsz' 144, 'SOFT' 0",
+                    fontWeight: 300,
+                  }}
+                >
+                  {String(i + 1).padStart(2, '0')}
+                </span>
+                <span className="mono-cap-sm text-ink-soft mt-4">
+                  — {String(i + 1).padStart(2, '0')} / {String(config.offerings.length).padStart(2, '0')} —
+                </span>
+              </div>
+              <h3
+                className="font-serif italic text-ink text-2xl md:text-3xl mb-4 leading-tight"
+                style={{ fontVariationSettings: "'opsz' 36, 'SOFT' 60, 'WONK' 1" }}
+              >
+                {t(offering.title)}
+              </h3>
+              <p className="text-ink-soft leading-relaxed text-[0.98rem]">
+                {t(offering.description)}
+              </p>
+            </article>
           ))}
         </div>
       </div>

--- a/src/components/home/OrganizersSection.tsx
+++ b/src/components/home/OrganizersSection.tsx
@@ -11,29 +11,86 @@ export default function OrganizersSection({ config }: Props) {
   const { t } = useLang();
 
   return (
-    <section className="py-24 px-4">
-      <div className="max-w-3xl mx-auto">
-        <div className="text-center mb-14">
-          <span className="line-ornament mb-6" />
-          <h2 className="font-serif text-3xl md:text-4xl font-light text-text-hover italic">
-            {t(ui.organizers)}
-          </h2>
+    <section className="relative py-28 md:py-36 px-6 md:px-10">
+      <div className="max-w-[1400px] mx-auto">
+        <div className="rule-strip mb-20">
+          <span className="rule-label text-clay">§ 04</span>
+          <span className="rule-line" />
+          <span className="rule-label">{t(ui.organizers)}</span>
+          <span className="rule-line" />
         </div>
-        <div className="grid md:grid-cols-2 gap-12">
-          {config.organizers.map((org, i) => (
-            <div key={i} className="text-center">
-              <div className="w-40 h-40 rounded-full overflow-hidden mx-auto mb-6 ring-1 ring-accent/20 ring-offset-4 ring-offset-bg">
-                <img
-                  src={assetUrl(org.image)}
-                  alt={t(org.name)}
-                  className="w-full h-full object-cover object-top scale-125"
-                />
-              </div>
-              <h3 className="font-serif text-text-hover text-xl mb-1 italic">{t(org.name)}</h3>
-              <p className="text-accent text-sm tracking-wide mb-3">{t(org.role)}</p>
-              <p className="text-text text-sm leading-relaxed">{t(org.bio)}</p>
-            </div>
-          ))}
+
+        <h2
+          className="display-italic mb-20"
+          style={{
+            fontSize: 'clamp(2.2rem, 5vw, 4.5rem)',
+            fontVariationSettings: "'opsz' 144, 'SOFT' 70, 'WONK' 1",
+          }}
+        >
+          {t(ui.organizers)}
+        </h2>
+
+        <div className="grid md:grid-cols-2 gap-x-12 gap-y-20">
+          {config.organizers.map((org, i) => {
+            const isOdd = i % 2 === 1;
+            return (
+              <article
+                key={i}
+                className={`grid grid-cols-[auto_1fr] gap-x-6 ${isOdd ? 'md:mt-24' : ''}`}
+              >
+                {/* Number marker */}
+                <div className="flex flex-col items-center pt-2">
+                  <span className="mono-cap-sm text-clay">
+                    {String(i + 1).padStart(2, '0')}
+                  </span>
+                  <span className="mt-3 w-px flex-1 bg-ink/15" />
+                </div>
+
+                {/* Content */}
+                <div>
+                  <figure className="relative mb-7">
+                    <div
+                      className="paper-frame"
+                      style={{ transform: `rotate(${isOdd ? '0.8deg' : '-0.6deg'})` }}
+                    >
+                      <div className="aspect-[4/5] overflow-hidden">
+                        <img
+                          src={assetUrl(org.image)}
+                          alt={t(org.name)}
+                          loading="lazy"
+                          decoding="async"
+                          className="w-full h-full object-cover object-top"
+                          style={{ filter: 'sepia(0.08) saturate(0.95)' }}
+                        />
+                      </div>
+                      <span
+                        className="tape"
+                        style={{
+                          top: '-8px',
+                          [isOdd ? 'right' : 'left']: '32px',
+                          transform: `rotate(${isOdd ? '4deg' : '-3deg'})`,
+                        }}
+                      />
+                    </div>
+                    <figcaption className="mt-3 flex items-center gap-3 mono-cap-sm text-ink-soft">
+                      <span className="text-clay">Fig. {String(i + 1).padStart(2, '0')}</span>
+                      <span className="h-px w-10 bg-ink/20" />
+                      <span className="opacity-70">— {t(ui.portrait)} —</span>
+                    </figcaption>
+                  </figure>
+
+                  <h3
+                    className="font-serif text-2xl md:text-3xl text-ink mb-2 italic leading-tight"
+                    style={{ fontVariationSettings: "'opsz' 36, 'SOFT' 60, 'WONK' 1" }}
+                  >
+                    {t(org.name)}
+                  </h3>
+                  <p className="mono-cap-sm text-clay mb-4">{t(org.role)}</p>
+                  <p className="text-ink-soft leading-relaxed">{t(org.bio)}</p>
+                </div>
+              </article>
+            );
+          })}
         </div>
       </div>
     </section>

--- a/src/components/home/PricingSection.tsx
+++ b/src/components/home/PricingSection.tsx
@@ -11,39 +11,113 @@ export default function PricingSection({ config }: Props) {
   const { pricing } = config;
 
   return (
-    <section className="py-24 px-4 relative overflow-hidden">
-      <div className="absolute inset-0 bg-gradient-to-t from-bg-warm via-bg-warm/50 to-transparent" />
-      <div className="max-w-md mx-auto text-center relative">
-        <span className="line-ornament mb-6" />
-        <h2 className="font-serif text-3xl md:text-4xl font-light text-text-hover mb-10 italic">
-          {t(ui.pricing)}
-        </h2>
+    <section id="pricing" className="relative py-28 md:py-36 px-6 md:px-10 overflow-hidden">
+      <div
+        aria-hidden
+        className="absolute inset-0 pointer-events-none"
+        style={{
+          background:
+            'radial-gradient(ellipse 60% 50% at 50% 90%, rgba(177,75,42,0.08) 0%, transparent 65%)',
+        }}
+      />
 
-        <div className="border border-divider p-10">
-          <div className="font-serif text-5xl font-light text-text-hover mb-1">
-            {pricing.amount} {pricing.currency}
+      <div className="relative max-w-[1400px] mx-auto">
+        <div className="rule-strip mb-16">
+          <span className="rule-label text-clay">§ 07</span>
+          <span className="rule-line" />
+          <span className="rule-label">{t(ui.pricing)}</span>
+          <span className="rule-line" />
+        </div>
+
+        <div className="grid lg:grid-cols-12 gap-x-12 gap-y-14 items-start">
+          {/* LEFT — display price */}
+          <div className="lg:col-span-5 lg:sticky lg:top-32">
+            <p className="mono-cap-sm text-ink-soft mb-6">{t(ui.pricing)}</p>
+
+            <div className="flex items-start gap-4">
+              <span
+                className="font-serif text-ink leading-[0.85]"
+                style={{
+                  fontSize: 'clamp(7rem, 18vw, 16rem)',
+                  fontVariationSettings: "'opsz' 144, 'SOFT' 30, 'WONK' 0",
+                  fontWeight: 300,
+                  letterSpacing: '-0.04em',
+                }}
+              >
+                {pricing.amount}
+              </span>
+              <div className="pt-5 ml-1">
+                <p
+                  className="font-serif italic text-clay text-2xl md:text-3xl leading-none"
+                  style={{ fontVariationSettings: "'opsz' 24, 'SOFT' 70, 'WONK' 1" }}
+                >
+                  {pricing.currency}
+                </p>
+                <p className="mono-cap-sm text-ink-soft mt-3">{t(ui.perMonth)}</p>
+              </div>
+            </div>
+
+            <div className="mt-10 inline-flex items-center gap-3 px-4 py-2 border border-clay/50 text-clay bg-clay/5">
+              <span aria-hidden>✦</span>
+              <span className="mono-cap-sm">{t(pricing.trial)}</span>
+            </div>
+
+            <p className="mt-10 max-w-md text-ink-soft text-sm leading-relaxed">
+              {t(pricing.postPayment)}
+            </p>
           </div>
-          <p className="text-text text-sm mb-2">{t(ui.perMonth)}</p>
-          <p className="text-accent text-sm tracking-wide mb-8">{t(pricing.trial)}</p>
 
-          <ul className="text-left space-y-3 mb-10">
-            {pricing.benefits.map((benefit, i) => (
-              <li key={i} className="flex items-start gap-3 text-text text-sm">
-                <span className="text-gold mt-0.5">&#10003;</span>
-                <span>{t(benefit)}</span>
-              </li>
-            ))}
-          </ul>
+          {/* RIGHT — benefits + CTA */}
+          <div className="lg:col-span-7">
+            <h2
+              className="display-italic mb-10"
+              style={{
+                fontSize: 'clamp(2.2rem, 5vw, 4rem)',
+                fontVariationSettings: "'opsz' 144, 'SOFT' 70, 'WONK' 1",
+              }}
+            >
+              {t(ui.whatsInside)}
+            </h2>
 
-          <a
-            href={pricing.stripeLink}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-block w-full px-8 py-4 bg-accent text-white hover:bg-accent-hover transition-colors duration-300 text-sm tracking-[0.15em] uppercase"
-          >
-            {t(ui.subscribe)}
-          </a>
-          <p className="text-text text-xs mt-5">{t(pricing.postPayment)}</p>
+            <ul className="divide-y divide-ink/15 mb-10">
+              {pricing.benefits.map((benefit, i) => (
+                <li
+                  key={i}
+                  className="grid grid-cols-[auto_1fr_auto] items-baseline gap-5 py-4"
+                >
+                  <span className="font-mono text-xs text-clay tabular-nums">
+                    {String(i + 1).padStart(2, '0')}
+                  </span>
+                  <span
+                    className="font-serif text-lg text-ink leading-snug"
+                    style={{ fontVariationSettings: "'opsz' 20, 'SOFT' 40" }}
+                  >
+                    {t(benefit)}
+                  </span>
+                  <span aria-hidden className="text-clay/60">✓</span>
+                </li>
+              ))}
+            </ul>
+
+            <a
+              href={pricing.stripeLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group relative inline-flex w-full items-center justify-between gap-4 px-8 py-5 bg-ink text-paper hover:bg-clay transition-colors duration-400 no-underline"
+            >
+              <span
+                className="font-serif italic text-2xl md:text-3xl leading-none"
+                style={{ fontVariationSettings: "'opsz' 36, 'SOFT' 70, 'WONK' 1" }}
+              >
+                {t(ui.subscribe)}
+              </span>
+              <span className="flex items-center gap-3">
+                <span className="mono-cap-sm">{pricing.amount} {pricing.currency}</span>
+                <span className="w-8 h-px bg-paper transition-all duration-400 group-hover:w-14" />
+                <span aria-hidden>→</span>
+              </span>
+            </a>
+          </div>
         </div>
       </div>
     </section>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import LangSwitcher from './LangSwitcher';
 import { useLang } from '../../hooks/useLang';
 import { ui } from '../../lib/ui-strings';
@@ -7,60 +7,98 @@ import { ui } from '../../lib/ui-strings';
 export default function Header() {
   const { t } = useLang();
   const [menuOpen, setMenuOpen] = useState(false);
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 8);
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
 
   return (
-    <header className="fixed top-0 left-0 right-0 z-50 bg-bg/70 backdrop-blur-md">
-      <div className="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
-        <Link to="/" className="font-serif text-text-hover text-xl italic no-underline tracking-wide">
-          TC
-        </Link>
-
-        {/* Desktop nav */}
-        <nav className="hidden md:flex items-center gap-8">
-          <Link to="/" className="text-text hover:text-accent transition-colors no-underline text-xs tracking-[0.15em] uppercase">
-            {t(ui.home)}
+    <header
+      className={`fixed top-0 left-0 right-0 z-50 transition-colors duration-500 ${
+        scrolled ? 'bg-paper/85 backdrop-blur-md' : 'bg-transparent'
+      }`}
+    >
+      <div className="max-w-[1400px] mx-auto px-6 md:px-10 pt-4 md:pt-5 pb-3 md:pb-4">
+        <div className="flex items-center justify-between">
+          <Link
+            to="/"
+            className="group inline-flex items-baseline gap-2 no-underline"
+            aria-label="Transformation Club — home"
+          >
+            <span
+              className="display-italic text-2xl md:text-[28px] leading-none"
+              style={{ fontVariationSettings: "'opsz' 96, 'SOFT' 50, 'WONK' 1" }}
+            >
+              Transformation
+            </span>
+            <span className="mono-cap-sm text-clay -translate-y-px">CLUB</span>
           </Link>
-          <Link to="/archive" className="text-text hover:text-accent transition-colors no-underline text-xs tracking-[0.15em] uppercase">
-            {t(ui.archive)}
-          </Link>
-          <LangSwitcher />
-        </nav>
 
-        {/* Mobile hamburger */}
-        <button
-          className="md:hidden text-text-hover p-1"
-          onClick={() => setMenuOpen(!menuOpen)}
-          aria-label="Menu"
-        >
-          <svg width="24" height="24" fill="none" stroke="currentColor" strokeWidth="1.5">
-            {menuOpen ? (
-              <path d="M6 6l12 12M6 18L18 6" />
-            ) : (
-              <path d="M4 7h16M4 12h16M4 17h16" />
-            )}
-          </svg>
-        </button>
+          {/* Desktop nav */}
+          <nav className="hidden md:flex items-center gap-9">
+            <Link to="/" className="mono-cap-sm text-ink-soft hover:text-clay transition-colors no-underline ed-link">
+              {t(ui.home)}
+            </Link>
+            <Link to="/archive" className="mono-cap-sm text-ink-soft hover:text-clay transition-colors no-underline ed-link">
+              {t(ui.archive)}
+            </Link>
+            <span className="h-3 w-px bg-ink/30" aria-hidden />
+            <LangSwitcher />
+          </nav>
+
+          {/* Mobile hamburger */}
+          <button
+            className="md:hidden text-ink p-1 cursor-pointer"
+            onClick={() => setMenuOpen(!menuOpen)}
+            aria-label="Menu"
+            aria-expanded={menuOpen}
+          >
+            <svg width="22" height="22" fill="none" stroke="currentColor" strokeWidth="1.25">
+              {menuOpen ? <path d="M5 5l12 12M5 17L17 5" /> : <path d="M3 7h16M3 12h16M3 17h16" />}
+            </svg>
+          </button>
+        </div>
+
+        {/* Hairline rule with edition metadata */}
+        <div className="mt-3 hidden md:flex items-center gap-3 text-ink-soft/80">
+          <span className="mono-cap-sm">{t(ui.volume)}</span>
+          <span className="h-px flex-1 bg-ink/15" />
+          <span className="mono-cap-sm">{t(ui.issueLabel)} 05 · 26</span>
+          <span className="h-px w-10 bg-ink/15" />
+          <span className="mono-cap-sm text-clay">{t(ui.inSession)}</span>
+        </div>
       </div>
 
       {/* Mobile menu */}
       {menuOpen && (
-        <div className="md:hidden bg-bg/95 backdrop-blur-md px-6 pb-5 border-t border-divider/50">
-          <nav className="flex flex-col gap-4 pt-3">
+        <div className="md:hidden bg-paper/95 backdrop-blur-md px-6 pb-6 pt-2 border-t border-ink/10">
+          <nav className="flex flex-col gap-5">
             <Link
               to="/"
               onClick={() => setMenuOpen(false)}
-              className="text-text hover:text-accent transition-colors no-underline text-xs tracking-[0.15em] uppercase"
+              className="mono-cap text-ink hover:text-clay transition-colors no-underline"
             >
               {t(ui.home)}
             </Link>
             <Link
               to="/archive"
               onClick={() => setMenuOpen(false)}
-              className="text-text hover:text-accent transition-colors no-underline text-xs tracking-[0.15em] uppercase"
+              className="mono-cap text-ink hover:text-clay transition-colors no-underline"
             >
               {t(ui.archive)}
             </Link>
-            <LangSwitcher />
+            <div className="pt-2 border-t border-ink/10">
+              <LangSwitcher />
+            </div>
+            <div className="flex items-center gap-3 text-ink-soft/80 pt-3 border-t border-ink/10">
+              <span className="mono-cap-sm">{t(ui.volume)}</span>
+              <span className="h-px flex-1 bg-ink/15" />
+              <span className="mono-cap-sm">{t(ui.issueLabel)} 05 · 26</span>
+            </div>
           </nav>
         </div>
       )}

--- a/src/components/layout/LangSwitcher.tsx
+++ b/src/components/layout/LangSwitcher.tsx
@@ -11,19 +11,20 @@ export default function LangSwitcher() {
   const { lang, setLang } = useLang();
 
   return (
-    <div className="flex gap-1 text-sm">
-      {langs.map(({ code, label }) => (
-        <button
-          key={code}
-          onClick={() => setLang(code)}
-          className={`px-2 py-1 rounded transition-colors ${
-            lang === code
-              ? 'bg-accent text-white'
-              : 'text-text hover:text-text-hover'
-          }`}
-        >
-          {label}
-        </button>
+    <div className="inline-flex items-center gap-3 mono-cap-sm">
+      {langs.map(({ code, label }, i) => (
+        <span key={code} className="inline-flex items-center">
+          {i > 0 && <span className="mr-3 opacity-30">·</span>}
+          <button
+            onClick={() => setLang(code)}
+            className={`cursor-pointer transition-colors ${
+              lang === code ? 'text-clay' : 'text-ink-soft hover:text-ink'
+            }`}
+            aria-pressed={lang === code}
+          >
+            {label}
+          </button>
+        </span>
       ))}
     </div>
   );

--- a/src/components/shared/Marquee.tsx
+++ b/src/components/shared/Marquee.tsx
@@ -1,0 +1,34 @@
+import type { LocalizedString } from '../../types/month';
+import { useLang } from '../../hooks/useLang';
+
+interface Props {
+  tags: LocalizedString;
+}
+
+export default function Marquee({ tags }: Props) {
+  const { t } = useLang();
+  const raw = t(tags);
+  const items = raw
+    .split(/\s*[·•|]\s*/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  if (items.length === 0) return null;
+
+  const loopOnce = items.concat(items);
+
+  return (
+    <div className="marquee" aria-hidden="true">
+      <div className="marquee-track">
+        {loopOnce.map((item, i) => (
+          <span key={`a-${i}`}>{item}</span>
+        ))}
+      </div>
+      <div className="marquee-track" aria-hidden="true">
+        {loopOnce.map((item, i) => (
+          <span key={`b-${i}`}>{item}</span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,5 @@
 @import "tailwindcss";
-@import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT,WONK@0,9..144,200..900,0..100,0..1;1,9..144,200..900,0..100,0..1&family=IBM+Plex+Mono:ital,wght@0,300;0,400;0,500;1,400&display=swap');
 
 @font-face {
   font-family: 'CameraPlain';
@@ -9,17 +9,33 @@
 }
 
 @theme {
-  --color-bg: #F5EFE3;
-  --color-bg-warm: #EDE5D4;
-  --color-bg-card: #EAE1CE;
-  --color-text: #6D5D4E;
-  --color-text-hover: #2E1F15;
-  --color-accent: #C4704B;
-  --color-accent-hover: #A85C3A;
-  --color-divider: #DDD3C1;
-  --color-gold: #B89A5A;
+  /* Paper-and-ink palette */
+  --color-paper: #F0E7D6;
+  --color-paper-deep: #E5DAC4;
+  --color-paper-card: #EBE0CA;
+  --color-ink: #1A1410;
+  --color-ink-soft: #5E4F42;
+  --color-ink-faint: #8C7C6A;
+
+  /* Accents */
+  --color-clay: #B14B2A;
+  --color-clay-deep: #7E2F19;
+  --color-moss: #5A6745;
+  --color-gold: #9E7F3C;
+
+  /* Legacy aliases (kept so unmigrated routes still render) */
+  --color-bg: #F0E7D6;
+  --color-bg-warm: #E5DAC4;
+  --color-bg-card: #EBE0CA;
+  --color-text: #5E4F42;
+  --color-text-hover: #1A1410;
+  --color-accent: #B14B2A;
+  --color-accent-hover: #7E2F19;
+  --color-divider: #D4C8B2;
+
   --font-sans: 'CameraPlain', system-ui, -apple-system, sans-serif;
-  --font-serif: 'Cormorant Garamond', 'Georgia', serif;
+  --font-serif: 'Fraunces', 'Cormorant Garamond', 'Georgia', serif;
+  --font-mono: 'IBM Plex Mono', 'JetBrains Mono', ui-monospace, monospace;
 }
 
 html {
@@ -29,55 +45,233 @@ html {
 body {
   margin: 0;
   font-family: var(--font-sans);
+  color: var(--color-ink-soft);
+  background: var(--color-paper);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background-image:
-    radial-gradient(ellipse at 20% 0%, rgba(196, 112, 75, 0.06) 0%, transparent 60%),
-    radial-gradient(ellipse at 80% 100%, rgba(184, 154, 90, 0.06) 0%, transparent 60%);
+    radial-gradient(ellipse 80% 60% at 8% 4%, rgba(177, 75, 42, 0.07) 0%, transparent 55%),
+    radial-gradient(ellipse 70% 50% at 96% 92%, rgba(90, 103, 69, 0.06) 0%, transparent 55%),
+    radial-gradient(ellipse 50% 40% at 50% 50%, rgba(158, 127, 60, 0.04) 0%, transparent 60%);
 }
 
-/* Subtle grain overlay */
+/* Printed paper grain */
 body::before {
   content: '';
   position: fixed;
   inset: 0;
-  opacity: 0.03;
+  opacity: 0.055;
   pointer-events: none;
   z-index: 9999;
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
-  background-size: 256px 256px;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
+  background-size: 220px 220px;
+  mix-blend-mode: multiply;
+}
+
+/* Vertical edition stamp — runs down the left edge of the viewport */
+.edition-stamp {
+  position: fixed;
+  left: 18px;
+  top: 50%;
+  transform: translateY(-50%) rotate(-90deg);
+  transform-origin: center;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.42em;
+  color: var(--color-ink-soft);
+  text-transform: uppercase;
+  z-index: 40;
+  white-space: nowrap;
+  pointer-events: none;
+  mix-blend-mode: multiply;
+}
+@media (max-width: 768px) {
+  .edition-stamp { display: none; }
+}
+
+/* Editorial rule strip — thin line studded with mono captions */
+.rule-strip {
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+  width: 100%;
+  color: var(--color-ink-soft);
+}
+.rule-strip .rule-line {
+  flex: 1;
+  height: 1px;
+  background: currentColor;
+  opacity: 0.35;
+}
+.rule-strip .rule-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  opacity: 0.7;
+  white-space: nowrap;
+}
+
+/* Marquee */
+.marquee {
+  display: flex;
+  overflow: hidden;
+  border-block: 1px solid color-mix(in srgb, var(--color-ink) 18%, transparent);
+  background: var(--color-paper-deep);
+}
+.marquee-track {
+  display: flex;
+  gap: 3.5rem;
+  flex-shrink: 0;
+  padding: 1.1rem 1.75rem;
+  animation: marquee 45s linear infinite;
+  white-space: nowrap;
+  align-items: center;
+}
+.marquee-track > span {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: 1.5rem;
+  color: var(--color-ink);
+  letter-spacing: -0.01em;
+}
+.marquee-track > span::before {
+  content: '✦';
+  display: inline-block;
+  margin-right: 3.5rem;
+  color: var(--color-clay);
+  font-style: normal;
+  font-size: 0.7em;
+  vertical-align: 0.15em;
+}
+@keyframes marquee {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .marquee-track { animation: none; }
 }
 
 /* Section entrance animations */
 @keyframes fadeUp {
-  from {
-    opacity: 0;
-    transform: translateY(24px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+  from { opacity: 0; transform: translateY(28px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
-
 @keyframes fadeIn {
   from { opacity: 0; }
-  to { opacity: 1; }
+  to   { opacity: 1; }
 }
-
-.animate-fade-up {
-  animation: fadeUp 0.8s cubic-bezier(0.22, 1, 0.36, 1) both;
+@keyframes lineGrow {
+  from { transform: scaleX(0); }
+  to   { transform: scaleX(1); }
 }
-
-.animate-fade-in {
-  animation: fadeIn 0.6s ease both;
+@keyframes letterRise {
+  from { opacity: 0; transform: translateY(0.5em) rotate(-2deg); }
+  to   { opacity: 1; transform: translateY(0) rotate(0); }
 }
+.animate-fade-up   { animation: fadeUp 0.9s cubic-bezier(0.22, 1, 0.36, 1) both; }
+.animate-fade-in   { animation: fadeIn 0.8s ease both; }
+.animate-line-grow {
+  display: inline-block;
+  transform-origin: left center;
+  animation: lineGrow 1.2s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+.animate-letter    { animation: letterRise 0.9s cubic-bezier(0.22, 1, 0.36, 1) both; display: inline-block; }
 
-/* Decorative thin line */
+/* Legacy ornament kept for parts not yet migrated */
 .line-ornament {
   display: inline-block;
   width: 48px;
   height: 1px;
-  background: var(--color-accent);
-  opacity: 0.5;
+  background: var(--color-clay);
+  opacity: 0.55;
 }
+
+/* Display type — large editorial italic, with Fraunces optical axis */
+.display-italic {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-weight: 300;
+  font-variation-settings: 'opsz' 144, 'SOFT' 35, 'WONK' 1;
+  letter-spacing: -0.02em;
+  line-height: 0.9;
+  color: var(--color-ink);
+}
+.display-roman {
+  font-family: var(--font-serif);
+  font-weight: 350;
+  font-variation-settings: 'opsz' 144, 'SOFT' 30, 'WONK' 0;
+  letter-spacing: -0.02em;
+  line-height: 0.95;
+  color: var(--color-ink);
+}
+
+/* Mono caption / tag */
+.mono-cap {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--color-ink-soft);
+}
+.mono-cap-sm {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--color-ink-soft);
+}
+
+/* Big paper-pinned image frame */
+.paper-frame {
+  position: relative;
+  background: var(--color-paper-deep);
+  padding: 10px;
+  box-shadow:
+    0 1px 0 rgba(26,20,16,0.08),
+    0 22px 38px -28px rgba(26,20,16,0.35);
+}
+.paper-frame::after {
+  content: '';
+  position: absolute;
+  inset: 10px;
+  pointer-events: none;
+  box-shadow: inset 0 0 0 1px rgba(26,20,16,0.08);
+}
+
+/* "Tape" corner — for collage pinning effect */
+.tape {
+  position: absolute;
+  width: 64px;
+  height: 18px;
+  background: color-mix(in srgb, var(--color-gold) 70%, var(--color-paper));
+  opacity: 0.65;
+  mix-blend-mode: multiply;
+}
+
+/* Hover lift for editorial cards */
+.editorial-card {
+  transition: transform 0.5s cubic-bezier(0.22, 1, 0.36, 1), border-color 0.4s ease;
+  will-change: transform;
+}
+.editorial-card:hover { transform: translateY(-4px); }
+
+/* Subtle underline-grow link */
+.ed-link {
+  position: relative;
+  display: inline-block;
+}
+.ed-link::after {
+  content: '';
+  position: absolute;
+  left: 0; right: 0; bottom: -3px;
+  height: 1px;
+  background: currentColor;
+  transform: scaleX(0.25);
+  transform-origin: left center;
+  transition: transform 0.5s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.ed-link:hover::after { transform: scaleX(1); }
+
+/* Selection */
+::selection { background: var(--color-clay); color: var(--color-paper); }

--- a/src/lib/ui-strings.ts
+++ b/src/lib/ui-strings.ts
@@ -21,6 +21,15 @@ export const ui: Record<string, LocalizedString> = {
   archive: { ru: 'Архив', en: 'Archive', uk: 'Архів' },
   home: { ru: 'Главная', en: 'Home', uk: 'Головна' },
   april: { ru: 'Апрель', en: 'April', uk: 'Квітень' },
+  // Editorial chrome
+  inSession: { ru: 'В выпуске', en: 'In session', uk: 'У випуску' },
+  beginReading: { ru: 'Начать чтение', en: 'Begin reading', uk: 'Почати читання' },
+  editorsNote: { ru: 'Слово редактора', en: "Editor's note", uk: 'Слово редакторки' },
+  portrait: { ru: 'Портрет', en: 'Portrait', uk: 'Портрет' },
+  practice: { ru: 'Практика', en: 'Practice', uk: 'Практика' },
+  volume: { ru: 'Том V', en: 'Vol. V', uk: 'Том V' },
+  issueLabel: { ru: 'Выпуск', en: 'Issue', uk: 'Випуск' },
+  cover: { ru: 'Обложка', en: 'Cover', uk: 'Обкладинка' },
 };
 
 export const monthNames: Record<string, LocalizedString> = {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -8,31 +8,41 @@ import GuestSection from '../components/home/GuestSection';
 import OfferingsSection from '../components/home/OfferingsSection';
 import PricingSection from '../components/home/PricingSection';
 import ContactSection from '../components/home/ContactSection';
+import Marquee from '../components/shared/Marquee';
+import { useLang } from '../hooks/useLang';
+import { ui } from '../lib/ui-strings';
 
 export default function HomePage() {
   const config = useSiteConfig();
   const monthIndex = useMonthIndex();
   const currentMonth = useMonth(monthIndex?.current);
+  const { t } = useLang();
 
   if (!config || !currentMonth) {
     return (
       <div className="min-h-screen flex items-center justify-center">
-        <div className="w-8 h-8 border-2 border-accent border-t-transparent rounded-full animate-spin" />
+        <div className="w-8 h-8 border-2 border-clay border-t-transparent rounded-full animate-spin" />
       </div>
     );
   }
 
   return (
-    <main>
-      <HeroSection config={config} month={currentMonth} />
-      <AboutSection config={config} />
-      <MonthStructure month={currentMonth} />
-      <MonthScheduleSection month={currentMonth} />
-      <OrganizersSection config={config} />
-      <GuestSection month={currentMonth} />
-      <OfferingsSection config={config} />
-      <PricingSection config={config} />
-      <ContactSection />
-    </main>
+    <>
+      <span className="edition-stamp" aria-hidden="true">
+        {t(ui.volume)} · {t(ui.issueLabel)} · 05 · 26 · {t(config.about.title)}
+      </span>
+      <main>
+        <HeroSection config={config} month={currentMonth} />
+        <Marquee tags={config.about.tags} />
+        <AboutSection config={config} />
+        <MonthStructure month={currentMonth} />
+        <MonthScheduleSection month={currentMonth} />
+        <OrganizersSection config={config} />
+        <GuestSection month={currentMonth} />
+        <OfferingsSection config={config} />
+        <PricingSection config={config} />
+        <ContactSection />
+      </main>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

Reframes the landing flow (hero → theme → guests → pricing → contact) as a single issue of a quarterly journal. New typography (Fraunces variable italic + IBM Plex Mono on top of existing CameraPlain), a paper-and-ink palette with saturated clay and moss accents, and recurring editorial signatures:

- Rule-strip section masts (`§ 01 — About the club —`)
- Vertical edition stamp running down the viewport edge
- Paper-pinned photographs with tape corners
- Looping italic tag marquee after the hero
- Asymmetric grids alternating left/right alignment
- Varied portrait collage for the guest section (different layouts per index)
- Cascading italic theme display (e.g. `Моё` / `Тело`)
- Display-type price block with bold subscribe CTA

New localized labels added (`volume`, `issueLabel`, `inSession`, `beginReading`, `editorsNote`, `portrait`, `practice`, `cover`) so editorial chrome is not English-only. Legacy color aliases preserved so `MonthDetailPage` and other untouched routes still render.

## Files

- `src/index.css` — design system: fonts, palette, primitives (`rule-strip`, `paper-frame`, `marquee`, `edition-stamp`), animations
- `src/components/layout/Header.tsx` + `LangSwitcher.tsx` — editorial mast
- `src/components/home/*` — nine section rewrites
- `src/components/shared/Marquee.tsx` — new shared component
- `src/pages/HomePage.tsx` — wires marquee + edition stamp
- `src/lib/ui-strings.ts` — new ru/en/uk editorial labels

## Verification

- [x] `npx tsc -b` passes (0 errors)
- [x] `npx eslint` passes on touched files (0 errors)
- [ ] Vercel preview — watch this PR for the deploy

## Test plan

- [ ] Open Vercel preview, verify hero cascade renders for each language (RU/EN/UK)
- [ ] Check the 5-guest portrait collage layout (varied positions per index)
- [ ] Hover the pricing CTA and verify the rule expands
- [ ] Mobile: confirm hero theme title doesn't overflow with long Cyrillic words
- [ ] Verify marquee scrolls smoothly and respects `prefers-reduced-motion`
- [ ] Check existing `/archive` route still renders (uses legacy color aliases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added edition metadata display (volume, issue, session information) in header and page footer.
  * Introduced marquee section with rotating content tags.

* **Style**
  * Redesigned all major page sections with modern grid-based layouts and improved visual hierarchy.
  * Updated typography with new serif font and enhanced editorial styling.
  * Added structural design elements including numbered entries, paper frames, and rule-strip headers.
  * Refreshed color palette and backgrounds throughout.
  * Enhanced scroll-dependent header styling with backdrop blur effects.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/olegleyz/tclub/pull/11)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->